### PR TITLE
Improve (write, generate) API documentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,7 @@ dependencies = [
  "base64 0.22.1",
  "crc32fast",
  "cuid2",
+ "documentation-macro",
  "once_cell",
  "rand",
  "regex",
@@ -66,6 +67,32 @@ name = "archk-api"
 version = "0.1.0"
 dependencies = [
  "archk",
+ "axum",
+ "base64 0.22.1",
+ "bcrypt",
+ "crc32fast",
+ "cuid2",
+ "http-body-util",
+ "once_cell",
+ "rand",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "sqlx",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
+name = "archk-api-server"
+version = "0.1.0"
+dependencies = [
+ "archk",
+ "archk-api",
  "axum",
  "base64 0.22.1",
  "bcrypt",
@@ -384,6 +411,15 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "documentation-macro"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.70",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["archk", "archk-api"]
+members = ["archk", "archk-api", "archk-api-server", "documentation-macro"]
 
 [profile.release]
 lto = true

--- a/archk-api-server/Cargo.toml
+++ b/archk-api-server/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "archk-api"
+name = "archk-api-server"
 version = "0.1.0"
 edition = "2021"
 
@@ -27,8 +27,5 @@ sqlx = { version = "0.7", features = ["sqlite", "runtime-tokio"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 
-archk = { path = "../archk", features = ["axum", "derive"] }
-
-[build-dependencies]
-tokio = { version = "1", features = ["full"] }
-sqlx = { version = "0.7", features = ["sqlite", "runtime-tokio"] }
+archk = { path = "../archk", features = ["axum"] }
+archk-api = { path = "../archk-api" }

--- a/archk-api-server/src/main.rs
+++ b/archk-api-server/src/main.rs
@@ -1,12 +1,8 @@
 use std::{fs, net::SocketAddrV4};
 
-use app::{AppConfig, AppConfigServerPublishOnPort, AppState};
+use archk_api::app::{AppConfig, AppConfigServerPublishOnPort, AppState};
 use axum::{routing::get, Router};
 use sqlx::SqlitePool;
-
-mod app;
-mod roles;
-mod v1;
 
 #[tokio::main]
 async fn main() {
@@ -48,7 +44,7 @@ async fn main() {
         .await
         .expect("db connection");
 
-    if let Err(err) = sqlx::migrate!().run(&db).await {
+    if let Err(err) = archk_api::apply_migrations(&db).await {
         eprintln!("Failed to migrate on `{}`: {err}", config.database);
         panic!("failed to migrate: {err}");
     }
@@ -59,7 +55,7 @@ async fn main() {
     };
 
     let app = Router::new()
-        .nest("/api/v1", v1::get_routes())
+        .nest("/api/v1", archk_api::v1::get_routes())
         .route("/", get(|| async { String::from("hi") }))
         .with_state(state);
 

--- a/archk-api/src/lib.rs
+++ b/archk-api/src/lib.rs
@@ -1,0 +1,9 @@
+use sqlx::SqlitePool;
+
+pub mod app;
+pub mod roles;
+pub mod v1;
+
+pub async fn apply_migrations(db: &SqlitePool) -> Result<(), sqlx::migrate::MigrateError> {
+    sqlx::migrate!().run(db).await
+}

--- a/archk-api/src/v1/auth.rs
+++ b/archk-api/src/v1/auth.rs
@@ -1,21 +1,27 @@
-use archk::v1::{
-    api::{self, Response},
-    auth::{Token, TokenTy},
-    user::is_valid_username,
+use archk::{
+    v1::{
+        api::{self, Response},
+        auth::{Token, TokenTy},
+        user::is_valid_username,
+    },
+    Documentation,
 };
 use axum::{extract::State, Json};
 use serde::{Deserialize, Serialize};
 
 use crate::app::AppState;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Documentation)]
 pub struct AuthorizationRequestData {
+    /// User name
     pub username: String,
+    /// User password
     pub password: String,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Documentation)]
 pub struct AuthorizationResponse {
+    /// Bearer token
     pub token: String,
 }
 

--- a/archk-api/src/v1/mod.rs
+++ b/archk-api/src/v1/mod.rs
@@ -18,27 +18,28 @@ use crate::app::AppState;
 
 mod auth;
 mod extra;
+pub mod routes;
 mod space;
 mod user;
 
 pub fn get_routes() -> Router<AppState> {
-    Router::new()
-        .route("/auth", post(auth::authorize))
-        .route("/users", get(user::get_users))
-        .route("/users/roles", get(user::get_all_roles))
-        .route("/user", get(user::get_self))
-        .route("/user", put(user::register))
-        .route("/user", patch(user::patch_user))
-        .route("/user/spaces", get(user::get_spaces))
-        .route("/user/@:user_id", get(user::get_user))
-        .route("/user/@:user_id", patch(user::reset_user_password))
-        .route("/user/@:user_id/role", get(user::get_user_role))
-        .route("/user/@:user_id/role", patch(user::promote_user))
-        .route("/user/@:user_id/spaces", get(user::get_user_spaces))
-        .route("/user/invites", get(user::get_invites))
-        .route("/user/invites", put(user::create_invite))
-        .route("/user/invites/wave", post(user::invite_wave))
-        .route("/space", put(space::create_space))
+    routes::get_routes()
+        // .route("/auth", post(auth::authorize))
+        // .route("/users", get(user::get_users))
+        // .route("/users/roles", get(user::get_all_roles))
+        // .route("/user", get(user::get_self))
+        // .route("/user", put(user::register))
+        // .route("/user", patch(user::patch_user))
+        // .route("/user/spaces", get(user::get_spaces))
+        // .route("/user/@:user_id", get(user::get_user))
+        // .route("/user/@:user_id", patch(user::reset_user_password))
+        // .route("/user/@:user_id/role", get(user::get_user_role))
+        // .route("/user/@:user_id/role", patch(user::promote_user))
+        // .route("/user/@:user_id/spaces", get(user::get_user_spaces))
+        // .route("/user/invites", get(user::get_invites))
+        // .route("/user/invites", put(user::create_invite))
+        // .route("/user/invites/wave", post(user::invite_wave))
+        // .route("/space", put(space::create_space))
         .route(
             "/space/:space_id",
             get(space::get_space)

--- a/archk-api/src/v1/routes.rs
+++ b/archk-api/src/v1/routes.rs
@@ -1,0 +1,69 @@
+use axum::{routing::get, Router};
+
+use crate::app::AppState;
+use archk::v1::docs;
+
+macro_rules! routes {
+    (@method GET $handler:path) => { get($handler) };
+    (@method POST $handler:path) => { post($handler) };
+    (@method PUT $handler:path) => { put($handler) };
+    (@method PATCH $handler:path) => { patch($handler) };
+    (@method DELETE $handler:path) => { delete($handler) };
+    ( $( $(#[doc = $d:literal])* $method:ident $path:literal => $handler:path $( : $( body($body:path) )? $( res($res:path) )? )? ),* $(,)? ) => {
+        /// Get [`axum::Router`] to all endpoints without any fallback or layer.
+        /// Use `v1::get_routes()` to include services and fallback
+        // $(
+        //     #[doc = concat!("# ", stringify!($method), " `", $path, "`")]
+        //     $( #[doc = $d] )*
+        // )*
+        pub fn get_routes() -> Router<AppState> {
+            Router::new()
+                $( .route($path, routes!(@method $method $handler)) )*
+        }
+
+        pub const ENDPOINTS: &[docs::Endpoint] = &[$(
+            docs::Endpoint {
+                method: docs::EndpointMethod::$method,
+                path: $path,
+                description: concat!( $($d, "\n",)* ),
+                $(
+                    $( body: Some( docs::documentation_object::<$body>() ), )?
+                    $( response: Some( docs::documentation_object::<$res>() ), )?
+                )?
+                ..docs::_EMPTY_ENDPOINT // fills `body` and `response` with `None`
+            }
+        ),*
+        ];
+    };
+}
+
+use super::*;
+
+routes! {
+    /// Authorize and obtain token.
+    POST "/auth" => auth::authorize
+        :   body(auth::AuthorizationRequestData)
+            res(auth::AuthorizationResponse),
+
+    /// Get all users. Supports paging.
+    /// Can be accessed by any user.
+    GET "/users" => user::get_users,
+    /// Get all possible roles on current instance.
+    /// Can be accessed by any user.
+    GET "/users/roles" => user::get_all_roles,
+
+    GET   "/user" => user::get_self,
+    PUT   "/user" => user::register,
+    PATCH "/user" => user::patch_user,
+    GET   "/user/spaces" => user::get_spaces,
+    GET   "/user/@:user_id" => user::get_user,
+    PATCH "/user/@:user_id" => user::reset_user_password,
+    GET   "/user/@:user_id/role" => user::get_user_role,
+    PATCH "/user/@:user_id/role" => user::promote_user,
+    GET   "/user/@:user_id/spaces" => user::get_user_spaces,
+    GET   "/user/invites" => user::get_invites,
+    PUT   "/user/invites" => user::create_invite,
+    POST  "/user/invites/wave" => user::invite_wave,
+
+    PUT   "/space" => space::create_space,
+}

--- a/archk/Cargo.toml
+++ b/archk/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [features]
 default = []
 axum = ["dep:axum"]
+derive = ["dep:documentation-macro"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
@@ -19,6 +20,8 @@ regex = "1"
 uuid = { version = "1.10", features = ["v4", "fast-rng"] }
 
 axum = { version = "0.7", optional = true }
+
+documentation-macro = { path = "../documentation-macro", optional = true }
 
 [dev-dependencies]
 serde_json = "1"

--- a/archk/src/lib.rs
+++ b/archk/src/lib.rs
@@ -1,2 +1,5 @@
 /// API version 1 endpoints and models
 pub mod v1;
+
+#[cfg(feature = "derive")]
+pub use documentation_macro::Documentation;

--- a/archk/src/v1/docs.rs
+++ b/archk/src/v1/docs.rs
@@ -1,0 +1,121 @@
+use super::models::MayIgnored;
+
+/// Field of struct
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DocumentationField {
+    /// Field name
+    pub name: &'static str,
+    /// Field rust type
+    pub ty: &'static str,
+    /// Field description
+    pub description: &'static str,
+}
+
+/// Represents [`Documentation`] but in struct. Can be obtained from [`DocumentationExt::documentation_object`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DocumentationObject {
+    /// Type name
+    pub name: &'static str,
+    /// Struct fields
+    pub fields: &'static [DocumentationField],
+
+    /// Is this type array?
+    pub is_array: bool,
+    /// Is this type nullable?
+    pub is_option: bool,
+    /// Is this type may not exists in object?
+    pub is_may_ignored: bool,
+}
+
+/// Described type or struct
+pub trait Documentation {
+    /// Type name
+    const NAME: &'static str;
+    /// Struct fields
+    const FIELDS: &'static [DocumentationField];
+
+    /// Is this type array?
+    const IS_ARRAY: bool = false;
+    /// Is this type nullable?
+    const IS_OPTION: bool = false;
+    /// Is this type may not exists in object?
+    const IS_MAY_IGNORED: bool = false;
+}
+
+macro_rules! impl_elementary {
+    ($($v:ident)*) => {
+        $(
+            impl Documentation for $v {
+                const NAME: &'static str = stringify!($v);
+                const FIELDS: &'static [DocumentationField] = &[];
+            }
+    )   *
+    };
+}
+impl_elementary!(String i8 i16 i32 i64 i128 u8 u16 u32 u64 u128);
+
+impl<T: Documentation> Documentation for Vec<T> {
+    const NAME: &'static str = T::NAME;
+    const FIELDS: &'static [DocumentationField] = T::FIELDS;
+
+    const IS_ARRAY: bool = true;
+    const IS_MAY_IGNORED: bool = T::IS_MAY_IGNORED;
+    const IS_OPTION: bool = T::IS_OPTION;
+}
+
+impl<T: Documentation> Documentation for Option<T> {
+    const NAME: &'static str = T::NAME;
+    const FIELDS: &'static [DocumentationField] = T::FIELDS;
+
+    const IS_ARRAY: bool = T::IS_ARRAY;
+    const IS_OPTION: bool = true;
+    const IS_MAY_IGNORED: bool = T::IS_MAY_IGNORED;
+}
+
+impl<T: Documentation> Documentation for MayIgnored<T> {
+    const NAME: &'static str = T::NAME;
+    const FIELDS: &'static [DocumentationField] = T::FIELDS;
+
+    const IS_ARRAY: bool = T::IS_ARRAY;
+    const IS_OPTION: bool = T::IS_OPTION;
+    const IS_MAY_IGNORED: bool = true;
+}
+
+/// Obtain [`DocumentationObject`] (for example, to store in vector)
+pub const fn documentation_object<T: Documentation>() -> DocumentationObject {
+    DocumentationObject {
+        name: T::NAME,
+        fields: T::FIELDS,
+        is_array: T::IS_ARRAY,
+        is_option: T::IS_OPTION,
+        is_may_ignored: T::IS_MAY_IGNORED,
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EndpointMethod {
+    GET,
+    POST,
+    PUT,
+    PATCH,
+    DELETE,
+}
+
+pub struct Endpoint {
+    pub method: EndpointMethod,
+    pub path: &'static str,
+    pub description: &'static str,
+    pub body: Option<DocumentationObject>,
+    pub response: Option<DocumentationObject>,
+}
+
+// Pseudo-Default implementation of Endpoint. `method`, `path` and `description` should be filled.
+// Used only in macroses. Subject to remove
+#[doc(hidden)]
+pub const _EMPTY_ENDPOINT: Endpoint = Endpoint {
+    method: EndpointMethod::GET,
+    path: "",
+    description: "",
+    body: None,
+    response: None,
+};

--- a/archk/src/v1/mod.rs
+++ b/archk/src/v1/mod.rs
@@ -10,6 +10,7 @@ pub mod models;
 
 /// Declaration of API response structure
 pub mod api;
+pub mod docs;
 
 /// Errors used in some models
 pub mod errors {

--- a/documentation-macro/Cargo.toml
+++ b/documentation-macro/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "documentation-macro"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "2.0", features = ["full"] }
+quote = "1.0"
+proc-macro2 = "1.0"

--- a/documentation-macro/src/lib.rs
+++ b/documentation-macro/src/lib.rs
@@ -1,0 +1,61 @@
+use proc_macro::TokenStream;
+use quote::{quote, ToTokens};
+use syn::{parse_macro_input, DeriveInput, Expr, Lit, Meta, MetaNameValue};
+
+#[proc_macro_derive(Documentation)]
+pub fn documentation_derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    impl_documentation(&input)
+}
+
+fn impl_documentation(ast: &DeriveInput) -> TokenStream {
+    let name = &ast.ident;
+
+    let fields = if let syn::Data::Struct(data) = &ast.data {
+        data.fields
+            .iter()
+            .map(|field| {
+                let doc: String = field
+                    .attrs
+                    .iter()
+                    .flat_map(|attr| {
+                        if attr.path().is_ident("doc") {
+                            let Meta::NameValue(MetaNameValue { value, .. }) = &attr.meta else {
+                                return None;
+                            };
+                            let Expr::Lit(syn::ExprLit {
+                                lit: Lit::Str(s), ..
+                            }) = value
+                            else {
+                                return None;
+                            };
+
+                            Some(s.value())
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+                let ty = field.ty.to_token_stream().to_string();
+                let name = field.ident.as_ref().map(|v| v.to_string()).unwrap_or_else(|| "0".into());
+
+                quote! { ::archk::v1::docs::DocumentationField { name: #name, ty: #ty, description: #doc, } }
+            })
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+
+    let name_str = name.to_string();
+
+    let gen = quote! {
+        impl ::archk::v1::docs::Documentation for #name {
+            const NAME: &'static str = #name_str;
+            const FIELDS: &'static [::archk::v1::docs::DocumentationField] = &[
+                #(#fields),*
+            ];
+        }
+    };
+    gen.into()
+}


### PR DESCRIPTION
### To-Do list:
- [x] Make `#[derive(Documentation)]` macros.
- [ ] Write docs for it.
- [ ] Move all endpoints declarations to `archk-api/src/v1/routes.rs` (from `./mod.rs`)
- [ ] Write documentation for it.
- [ ] Write documentation for all used types in endpoints, derive `Documentation` macro to them.