### PR TITLE
Service accounts and SSH keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,6 +141,7 @@ dependencies = [
  "once_cell",
  "rand",
  "regex",
+ "russh-keys",
  "serde",
  "serde_json",
  "uuid",
@@ -270,6 +306,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,6 +343,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bcrypt-pbkdf"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aeac2e1fe888769f34f05ac343bbef98b14d1ffb292ab69d4608b3abc86f2a2"
+dependencies = [
+ "blowfish",
+ "pbkdf2 0.12.2",
+ "sha2",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,6 +373,15 @@ name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
 ]
@@ -347,6 +409,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,6 +428,17 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
 
 [[package]]
 name = "cipher"
@@ -469,6 +551,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,6 +570,15 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -495,6 +598,39 @@ dependencies = [
  "rand",
  "sha3",
 ]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.70",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "der"
@@ -520,6 +656,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "documentation-macro"
 version = "0.1.0"
 dependencies = [
@@ -535,12 +692,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -583,6 +800,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "flume"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,6 +839,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
 ]
 
 [[package]]
@@ -653,6 +901,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.70",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,8 +929,10 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -688,6 +949,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -702,10 +964,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gimli"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
 
 [[package]]
 name = "hashbrown"
@@ -886,6 +1169,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
 
@@ -930,6 +1214,16 @@ name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -979,6 +1273,12 @@ dependencies = [
  "cfg-if",
  "digest",
 ]
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -1155,10 +1455,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "rand_core",
+ "sha2",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1184,10 +1534,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest",
+ "hmac",
+ "password-hash",
+ "sha2",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
 
 [[package]]
 name = "pem-rfc7468"
@@ -1248,12 +1631,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs5"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
+dependencies = [
+ "aes",
+ "cbc",
+ "der",
+ "pbkdf2 0.12.2",
+ "scrypt",
+ "sha2",
+ "spki",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
+ "pkcs5",
+ "rand_core",
  "spki",
 ]
 
@@ -1264,10 +1664,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1336,6 +1768,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1365,6 +1808,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1378,9 +1831,71 @@ dependencies = [
  "pkcs1",
  "pkcs8",
  "rand_core",
+ "sha2",
  "signature",
  "spki",
  "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "russh-cryptovec"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fadd2c0ab350e21c66556f94ee06f766d8bdae3213857ba7610bfd8e10e51880"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "russh-keys"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb8c0bfe024d4edd242f65a2ac6c8bf38a892930050b9eb90909d8fc2c413c8d"
+dependencies = [
+ "aes",
+ "async-trait",
+ "bcrypt-pbkdf",
+ "block-padding",
+ "byteorder",
+ "cbc",
+ "ctr",
+ "data-encoding",
+ "der",
+ "digest",
+ "dirs",
+ "ecdsa",
+ "ed25519-dalek",
+ "elliptic-curve",
+ "futures",
+ "hmac",
+ "inout",
+ "log",
+ "md5",
+ "num-integer",
+ "p256",
+ "p384",
+ "p521",
+ "pbkdf2 0.11.0",
+ "pkcs1",
+ "pkcs5",
+ "pkcs8",
+ "rand",
+ "rand_core",
+ "rsa",
+ "russh-cryptovec",
+ "sec1",
+ "serde",
+ "sha1",
+ "sha2",
+ "spki",
+ "ssh-encoding",
+ "ssh-key",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "typenum",
  "zeroize",
 ]
 
@@ -1389,6 +1904,15 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -1416,10 +1940,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2 0.12.2",
+ "salsa20",
+ "sha2",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
@@ -1795,6 +2359,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "ssh-cipher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "cbc",
+ "chacha20",
+ "cipher",
+ "ctr",
+ "poly1305",
+ "ssh-encoding",
+ "subtle",
+]
+
+[[package]]
+name = "ssh-encoding"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
+dependencies = [
+ "base64ct",
+ "pem-rfc7468",
+ "sha2",
+]
+
+[[package]]
+name = "ssh-key"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca9b366a80cf18bb6406f4cf4d10aebfb46140a8c0c33f666a144c5c76ecbafc"
+dependencies = [
+ "bcrypt-pbkdf",
+ "ed25519-dalek",
+ "num-bigint-dig",
+ "p256",
+ "p384",
+ "p521",
+ "rand_core",
+ "rsa",
+ "sec1",
+ "sha2",
+ "signature",
+ "ssh-cipher",
+ "ssh-encoding",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2097,6 +2712,16 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "unsafe-libyaml"

--- a/archk-api/migrations/0002_service_accounts.sql
+++ b/archk-api/migrations/0002_service_accounts.sql
@@ -12,6 +12,7 @@ CREATE INDEX idx_users_ssh_keys_fingerprint ON users_ssh_keys(pubkey_fingerprint
 
 CREATE TABLE service_accounts (
     id TEXT NOT NULL PRIMARY KEY,
+    name TEXT NOT NULL,
     space_id TEXT DEFAULT NULL,
     ty INTEGER NOT NULL,
 

--- a/archk-api/migrations/0002_service_accounts.sql
+++ b/archk-api/migrations/0002_service_accounts.sql
@@ -1,6 +1,6 @@
 CREATE TABLE users_ssh_keys (
     id TEXT NOT NULL PRIMARY KEY,
-    pubkey_ty TEXT NOT NULL,
+    pubkey_ty INTEGER NOT NULL,
     pubkey_val TEXT NOT NULL,
     pubkey_fingerprint TEXT NOT NULL,
     owner_id TEXT NOT NULL,

--- a/archk-api/migrations/0002_service_accounts.sql
+++ b/archk-api/migrations/0002_service_accounts.sql
@@ -1,0 +1,29 @@
+CREATE TABLE users_ssh_keys (
+    id TEXT NOT NULL PRIMARY KEY,
+    pubkey_ty TEXT NOT NULL,
+    pubkey_val TEXT NOT NULL,
+    pubkey_fingerprint TEXT NOT NULL,
+    owner_id TEXT NOT NULL,
+
+    UNIQUE(pubkey_ty, pubkey_val),
+    FOREIGN KEY(owner_id) REFERENCES users(id) ON DELETE CASCADE
+);
+CREATE INDEX idx_users_ssh_keys_fingerprint ON users_ssh_keys(pubkey_fingerprint);
+
+CREATE TABLE service_accounts (
+    id TEXT NOT NULL PRIMARY KEY,
+    space_id TEXT DEFAULT NULL,
+    ty INTEGER NOT NULL,
+
+    FOREIGN KEY(space_id) REFERENCES spaces(id) ON DELETE CASCADE
+);
+
+CREATE TABLE service_tokens (
+    iat INTEGER NOT NULL,
+    rnd INTEGER NOT NULL,
+
+    service_id TEXT NOT NULL,
+
+    PRIMARY KEY(iat, rnd),
+    FOREIGN KEY(service_id) REFERENCES service_accounts(id) ON DELETE CASCADE
+);

--- a/archk-api/src/roles.rs
+++ b/archk-api/src/roles.rs
@@ -36,7 +36,7 @@ pub struct UserRole {
     pub permissions: RolePermissions,
 }
 
-#[derive(Serialize, Deserialize, Default, Documentation)]
+#[derive(Serialize, Deserialize, Default, Clone, Documentation)]
 pub struct RolePermissions {
     /// Promote users to current role or demote if role less than current.
     #[serde(default)]
@@ -54,4 +54,11 @@ pub struct RolePermissions {
     /// Can manage spaces?
     #[serde(default)]
     pub spaces_manage: bool,
+
+    /// Can create and manage space-related services?
+    #[serde(default)]
+    pub services: bool,
+    /// Can manage all services and create admin services?
+    #[serde(default)]
+    pub services_manage: bool,
 }

--- a/archk-api/src/v1/extra.rs
+++ b/archk-api/src/v1/extra.rs
@@ -1,6 +1,8 @@
 use archk::v1::{
     api,
     auth::{Token, TokenTy},
+    service::{ServiceAccountID, ServiceAccountTy},
+    space::SpaceID,
     user::UserID,
 };
 use axum::{
@@ -19,6 +21,14 @@ pub struct DbUser {
     pub invited_by: Option<String>,
     pub level: i64,
     pub password_hash: String,
+}
+
+#[derive(Debug)]
+#[allow(dead_code)] // ???
+pub struct DbService {
+    pub id: ServiceAccountID,
+    pub space_id: Option<SpaceID>,
+    pub ty: ServiceAccountTy,
 }
 
 #[async_trait]
@@ -75,6 +85,41 @@ impl AuthenticatedUserParam for DbUser {
         .fetch_optional(&state.db)
         .await
         .expect("database")
+    }
+}
+
+#[async_trait]
+impl AuthenticatedUserParam for DbService {
+    async fn verify(token: &Token, state: &AppState) -> Option<Self> {
+        if token.ty != TokenTy::Service {
+            return None;
+        }
+
+        let iat = token.iat as i64;
+        let rnd = token.rnd as i64;
+
+        let res = sqlx::query!(
+            "
+                SELECT
+                    service_tokens.service_id as id,
+                    service_accounts.space_id,
+                    service_accounts.ty
+                FROM service_tokens
+                    INNER JOIN service_accounts
+                        ON service_tokens.service_id = service_accounts.id
+                WHERE service_tokens.iat = ? AND service_tokens.rnd = ?",
+            iat,
+            rnd
+        )
+        .fetch_optional(&state.db)
+        .await
+        .expect("database")?;
+
+        Some(Self {
+            id: ServiceAccountID::from(res.id)?,
+            space_id: res.space_id.map(SpaceID::from).flatten(),
+            ty: ServiceAccountTy::try_from(res.ty).ok()?,
+        })
     }
 }
 

--- a/archk-api/src/v1/mod.rs
+++ b/archk-api/src/v1/mod.rs
@@ -19,6 +19,7 @@ use crate::app::AppState;
 mod auth;
 mod extra;
 pub mod routes;
+mod service;
 mod space;
 mod user;
 

--- a/archk-api/src/v1/routes.rs
+++ b/archk-api/src/v1/routes.rs
@@ -98,6 +98,17 @@ routes! {
     POST  "/user/invites/wave" => user::invite_wave
         :   res(u64),
 
+    /// Get own SSH keys
+    GET "/user/ssh-keys" => user::get_ssh_keys
+        :   res(Vec<archk::v1::user::ssh::UserSSHKey>),
+    /// Upload SSH key
+    PUT "/user/ssh-keys" => user::upload_ssh_key
+        :   body(user::UploadSSHKeyBody)
+            res(archk::v1::user::ssh::UserSSHKey),
+    /// Delete ssh key by their CUID
+    DELETE "/user/ssh-keys/:key_id" => user::delete_ssh_key
+        :   res(u64),
+
     /// Create space
     PUT   "/space" => space::create_space,
 

--- a/archk-api/src/v1/routes.rs
+++ b/archk-api/src/v1/routes.rs
@@ -131,4 +131,22 @@ routes! {
     GET    "/space/:space_id/item/:item_id" => space::get_item_by_id,
     PATCH  "/space/:space_id/item/:item_id" => space::patch_item,
     DELETE "/space/:space_id/item/:item_id" => space::delete_item,
+
+    /// Get services bound to space. Supports pagging.
+    GET "/space/:space_id/services" => service::get_space_services
+        :   res(Vec<service::ServiceAccountResponse>),
+
+    /// Get admin services. If query param `?all=true` passed shows all services including from spaces.
+    /// Supports paging.
+    GET "/service" => service::get_services
+        :   res(Vec<service::ServiceAccountResponse>),
+    /// Creates new service.
+    PUT "/service" => service::create_service
+        // FIXME: real return type is `archk::v1::service::ServiceAccount`
+        // FIXME: uncomment body() when spaces will be documentated
+        :   //body(service::CreateServiceBody)
+            res(service::ServiceAccountResponse),
+    /// Delete service account
+    DELETE "/service/:service_account_id" => service::delete_service
+        :   res(u64),
 }

--- a/archk-api/src/v1/routes.rs
+++ b/archk-api/src/v1/routes.rs
@@ -159,4 +159,9 @@ routes! {
     /// Revoke all tokens
     DELETE "/service/:service_account_id/tokens" => service::revoke_all_tokens
         :   res(u64),
+
+    /// Get all ssh keys matching fingerprint. Returns error no one key matches.
+    POST "/service/_/ssh-keys" => service::ssh::fetch_ssh_keys_by_fingerprint
+        :   body(service::ssh::FingerprintBody)
+            res(Vec<service::ssh::SSHKeyResponse>),
 }

--- a/archk-api/src/v1/routes.rs
+++ b/archk-api/src/v1/routes.rs
@@ -149,4 +149,14 @@ routes! {
     /// Delete service account
     DELETE "/service/:service_account_id" => service::delete_service
         :   res(u64),
+
+    /// Get tokens count for service
+    GET "/service/:service_account_id/tokens" => service::get_tokens
+        :   res(i32),
+    /// Issue new service token
+    PUT "/service/:service_account_id/tokens" => service::put_token
+        :   res(service::ServiceTokenResponse),
+    /// Revoke all tokens
+    DELETE "/service/:service_account_id/tokens" => service::revoke_all_tokens
+        :   res(u64),
 }

--- a/archk-api/src/v1/service.rs
+++ b/archk-api/src/v1/service.rs
@@ -1,0 +1,269 @@
+use archk::{
+    v1::{
+        api::{self, Response},
+        service::{ServiceAccount, ServiceAccountID, ServiceAccountTy},
+        space::SpaceID,
+    },
+    Documentation,
+};
+use axum::{
+    extract::{Path, Query, State},
+    Json,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::app::AppState;
+
+use super::{
+    extra::{AuthenticatedUser, DbUser},
+    space::SpacePath,
+};
+
+#[derive(Deserialize)]
+pub struct ServiceFetchOptions {
+    #[serde(default)]
+    pub page: u32,
+
+    #[serde(default)]
+    pub all: bool,
+}
+
+#[derive(Deserialize)]
+// FIXME: #[derive(Documentation)]
+pub struct CreateServiceBody {
+    /// Service type.
+    pub ty: ServiceAccountTy,
+    /// Space ID. Set to `null` to create admin service.
+    pub space_id: Option<SpaceID>,
+}
+
+#[derive(Deserialize)]
+pub struct ServiceAccountPath {
+    pub service_account_id: String,
+}
+
+#[derive(Serialize, Documentation)]
+pub struct ServiceAccountResponse {
+    /// Service ID
+    pub id: String,
+    /// Space ID service belongs to
+    pub space_id: Option<String>,
+    /// Service type
+    pub ty: i64,
+}
+
+pub async fn get_services(
+    Query(ServiceFetchOptions { page, all }): Query<ServiceFetchOptions>,
+    AuthenticatedUser {
+        user: DbUser { level, .. },
+        ..
+    }: AuthenticatedUser<DbUser>,
+    State(AppState { db, roles, .. }): State<AppState>,
+) -> Response<Vec<ServiceAccountResponse>> {
+    if roles
+        .get_current(level)
+        .filter(|v| v.permissions.services_manage)
+        .is_none()
+    {
+        return Response::Failture(api::Error::Forbidden.into());
+    }
+
+    let (limit, offset) = (50, 50 * page as i64);
+
+    let res = if all {
+        sqlx::query_as!(
+            ServiceAccountResponse,
+            "SELECT * FROM service_accounts LIMIT ? OFFSET ?",
+            limit,
+            offset
+        )
+        .fetch_all(&db)
+        .await
+    } else {
+        sqlx::query_as!(
+            ServiceAccountResponse,
+            "SELECT * FROM service_accounts WHERE space_id IS NULL LIMIT ? OFFSET ?",
+            limit,
+            offset
+        )
+        .fetch_all(&db)
+        .await
+    };
+
+    Response::Success(res.expect("database"))
+}
+
+pub async fn get_space_services(
+    Path(SpacePath { space_id }): Path<SpacePath>,
+    Query(ServiceFetchOptions { page, .. }): Query<ServiceFetchOptions>,
+    AuthenticatedUser {
+        user: DbUser {
+            id: user_id, level, ..
+        },
+        ..
+    }: AuthenticatedUser<DbUser>,
+    State(AppState { db, roles, .. }): State<AppState>,
+) -> Response<Vec<ServiceAccountResponse>> {
+    let is_admin = roles
+        .get_current(level)
+        .filter(|v| v.permissions.services_manage && v.permissions.spaces_manage)
+        .is_some();
+
+    let (limit, offset) = (50, 50 * page as i64);
+
+    let space_id: &str = &space_id;
+    let res = if is_admin {
+        sqlx::query_as!(
+            ServiceAccountResponse,
+            "
+            SELECT
+                service_accounts.id,
+                service_accounts.ty,
+                service_accounts.space_id
+            FROM service_accounts
+            WHERE service_accounts.space_id = ?
+            LIMIT ? OFFSET ?",
+            space_id,
+            limit,
+            offset
+        )
+        .fetch_all(&db)
+        .await
+    } else {
+        sqlx::query_as!(
+            ServiceAccountResponse,
+            "
+            SELECT
+                service_accounts.id,
+                service_accounts.ty,
+                service_accounts.space_id
+            FROM service_accounts
+                INNER JOIN spaces ON
+                    service_accounts.space_id = spaces.id
+            WHERE service_accounts.space_id = ? AND spaces.owner_id = ?
+            LIMIT ? OFFSET ?",
+            space_id,
+            user_id,
+            limit,
+            offset
+        )
+        .fetch_all(&db)
+        .await
+    };
+
+    Response::Success(res.expect("database"))
+}
+
+pub async fn create_service(
+    AuthenticatedUser {
+        user: DbUser {
+            id: user_id, level, ..
+        },
+        ..
+    }: AuthenticatedUser<DbUser>,
+    State(AppState { db, roles, .. }): State<AppState>,
+    Json(CreateServiceBody { ty, space_id }): Json<CreateServiceBody>,
+) -> Response<ServiceAccount> {
+    let perms = roles
+        .get_current(level)
+        .map(|v| &v.permissions)
+        .cloned()
+        .unwrap_or_default();
+
+    if !perms.services || (ty.is_admin() && !perms.services_manage) {
+        return Response::Failture(api::Error::Forbidden.into());
+    }
+
+    if space_id.is_none() && ty.is_space_required() {
+        return Response::Failture(
+            api::Error::MalformedData
+                .detail("this service type `ty` requires `space_id` to be specified".into()),
+        );
+    }
+
+    if let Some(ref space_id) = space_id {
+        if !perms.spaces_manage {
+            let space_id: &str = &space_id;
+            let res = sqlx::query!("SELECT owner_id FROM spaces WHERE id = ?", space_id)
+                .fetch_optional(&db)
+                .await
+                .expect("database")
+                .filter(|v| v.owner_id == user_id);
+
+            if res.is_none() {
+                return Response::Failture(api::Error::Forbidden.into());
+            }
+        }
+    }
+
+    let id = ServiceAccountID::new();
+    let id_str: &str = &id;
+    let space_id_ref = space_id.as_deref();
+    let ty_idx: i64 = ty.into();
+
+    let res = sqlx::query!(
+        "INSERT INTO service_accounts(id, ty, space_id) VALUES (?, ?, ?)",
+        id_str,
+        ty_idx,
+        space_id_ref
+    )
+    .execute(&db)
+    .await;
+
+    match res {
+        Err(sqlx::Error::Database(e)) if e.is_foreign_key_violation() => {
+            Response::Failture(api::Error::ObjectNotFound.into())
+        }
+        Ok(_) => Response::Success(ServiceAccount { id, ty, space_id }),
+        Err(e) => panic!("database error: {e}"),
+    }
+}
+
+pub async fn delete_service(
+    Path(ServiceAccountPath { service_account_id }): Path<ServiceAccountPath>,
+    AuthenticatedUser {
+        user: DbUser {
+            id: user_id, level, ..
+        },
+        ..
+    }: AuthenticatedUser<DbUser>,
+    State(AppState { db, roles, .. }): State<AppState>,
+) -> Response<u64> {
+    if roles
+        .get_current(level)
+        .filter(|v| v.permissions.services_manage)
+        .is_none()
+    {
+        let res = sqlx::query!(
+            "
+            SELECT spaces.owner_id
+            FROM service_accounts
+                INNER JOIN spaces ON spaces.id = service_accounts.space_id
+            WHERE service_accounts.id = ?",
+            service_account_id
+        )
+        .fetch_optional(&db)
+        .await
+        .expect("database")
+        .filter(|v| v.owner_id == user_id);
+
+        if res.is_none() {
+            return Response::Failture(api::Error::ObjectNotFound.into());
+        }
+    }
+
+    let res = sqlx::query!(
+        "DELETE FROM service_accounts WHERE id = ?",
+        service_account_id
+    )
+    .execute(&db)
+    .await
+    .expect("database")
+    .rows_affected();
+
+    if res == 0 {
+        Response::Failture(api::Error::ObjectNotFound.into())
+    } else {
+        Response::Success(res)
+    }
+}

--- a/archk-api/src/v1/service.rs
+++ b/archk-api/src/v1/service.rs
@@ -36,6 +36,8 @@ pub struct CreateServiceBody {
     pub ty: ServiceAccountTy,
     /// Space ID. Set to `null` to create admin service.
     pub space_id: Option<SpaceID>,
+    /// Service name
+    pub name: String,
 }
 
 #[derive(Deserialize)]
@@ -47,6 +49,8 @@ pub struct ServiceAccountPath {
 pub struct ServiceAccountResponse {
     /// Service ID
     pub id: String,
+    /// Service name
+    pub name: String,
     /// Space ID service belongs to
     pub space_id: Option<String>,
     /// Service type
@@ -125,6 +129,7 @@ pub async fn get_space_services(
             "
             SELECT
                 service_accounts.id,
+                service_accounts.name,
                 service_accounts.ty,
                 service_accounts.space_id
             FROM service_accounts
@@ -142,6 +147,7 @@ pub async fn get_space_services(
             "
             SELECT
                 service_accounts.id,
+                service_accounts.name,
                 service_accounts.ty,
                 service_accounts.space_id
             FROM service_accounts
@@ -169,7 +175,7 @@ pub async fn create_service(
         ..
     }: AuthenticatedUser<DbUser>,
     State(AppState { db, roles, .. }): State<AppState>,
-    Json(CreateServiceBody { ty, space_id }): Json<CreateServiceBody>,
+    Json(CreateServiceBody { ty, space_id, name }): Json<CreateServiceBody>,
 ) -> Response<ServiceAccount> {
     let perms = roles
         .get_current(level)
@@ -209,8 +215,9 @@ pub async fn create_service(
     let ty_idx: i64 = ty.into();
 
     let res = sqlx::query!(
-        "INSERT INTO service_accounts(id, ty, space_id) VALUES (?, ?, ?)",
+        "INSERT INTO service_accounts(id, name, ty, space_id) VALUES (?, ?, ?, ?)",
         id_str,
+        name,
         ty_idx,
         space_id_ref
     )

--- a/archk-api/src/v1/service.rs
+++ b/archk-api/src/v1/service.rs
@@ -1,6 +1,7 @@
 use archk::{
     v1::{
         api::{self, Response},
+        auth::{Token, TokenTy},
         service::{ServiceAccount, ServiceAccountID, ServiceAccountTy},
         space::SpaceID,
     },
@@ -50,6 +51,12 @@ pub struct ServiceAccountResponse {
     pub space_id: Option<String>,
     /// Service type
     pub ty: i64,
+}
+
+#[derive(Serialize, Documentation)]
+pub struct ServiceTokenResponse {
+    /// Bearer token
+    pub token: String,
 }
 
 pub async fn get_services(
@@ -266,4 +273,154 @@ pub async fn delete_service(
     } else {
         Response::Success(res)
     }
+}
+
+pub async fn get_tokens(
+    Path(ServiceAccountPath { service_account_id }): Path<ServiceAccountPath>,
+    AuthenticatedUser {
+        user: DbUser {
+            id: user_id, level, ..
+        },
+        ..
+    }: AuthenticatedUser<DbUser>,
+    State(AppState { db, roles, .. }): State<AppState>,
+) -> Response<i32> {
+    let (permission_services, permission_services_manage) = roles
+        .get_current(level)
+        .map(|v| (v.permissions.services, v.permissions.services_manage))
+        .unwrap_or_default();
+
+    if !permission_services {
+        return Response::Failture(api::Error::Forbidden.into());
+    }
+
+    let (is_none, count, owner_id) = sqlx::query!(
+        "
+        SELECT
+            (service_accounts.id IS NULL) AS is_none,
+            COUNT(service_tokens.service_id) as count,
+            spaces.owner_id AS owner_id
+        FROM service_accounts
+            INNER JOIN service_tokens
+                ON service_tokens.service_id = service_accounts.id
+            LEFT JOIN spaces
+                ON spaces.id = service_accounts.space_id
+        WHERE service_accounts.id = ?
+        ",
+        service_account_id
+    )
+    .fetch_one(&db)
+    .await
+    .map(|v| (v.is_none == 1, v.count, v.owner_id))
+    .expect("database");
+
+    if is_none || (owner_id != Some(user_id) && !permission_services_manage) {
+        return Response::Failture(api::Error::ObjectNotFound.into());
+    }
+
+    Response::Success(count)
+}
+
+pub async fn put_token(
+    Path(ServiceAccountPath { service_account_id }): Path<ServiceAccountPath>,
+    AuthenticatedUser {
+        user: DbUser {
+            id: user_id, level, ..
+        },
+        ..
+    }: AuthenticatedUser<DbUser>,
+    State(AppState { db, roles, .. }): State<AppState>,
+) -> Response<ServiceTokenResponse> {
+    let services_manage = roles
+        .get_current(level)
+        .filter(|v| v.permissions.services_manage)
+        .is_some();
+
+    let res = sqlx::query!(
+        "SELECT spaces.owner_id
+        FROM service_accounts
+            LEFT JOIN spaces ON spaces.id = service_accounts.space_id
+        WHERE service_accounts.id = ?",
+        service_account_id
+    )
+    .fetch_optional(&db)
+    .await
+    .expect("database")
+    .filter(|v| services_manage || v.owner_id == Some(user_id));
+
+    // check is service exists and user have permission to use them
+    if res.is_none() {
+        return Response::Failture(api::Error::ObjectNotFound.into());
+    }
+
+    let token = Token::new(TokenTy::Service);
+    let iat = token.iat as i64;
+    let rnd = token.rnd as i64;
+
+    let res = sqlx::query!(
+        "INSERT INTO service_tokens(iat, rnd, service_id) VALUES (?, ?, ?)",
+        iat,
+        rnd,
+        service_account_id
+    )
+    .execute(&db)
+    .await;
+
+    match res {
+        Ok(_) => Response::Success(ServiceTokenResponse {
+            token: token.to_string(),
+        }),
+        Err(sqlx::Error::Database(e)) if e.is_foreign_key_violation() => {
+            tracing::warn!(
+                service_id = service_account_id,
+                "Database returned unexpected foreign key violation"
+            );
+            Response::Failture(api::Error::ObjectNotFound.into())
+        }
+        Err(e) => panic!("database error: {e}"),
+    }
+}
+
+pub async fn revoke_all_tokens(
+    Path(ServiceAccountPath { service_account_id }): Path<ServiceAccountPath>,
+    AuthenticatedUser {
+        user: DbUser {
+            id: user_id, level, ..
+        },
+        ..
+    }: AuthenticatedUser<DbUser>,
+    State(AppState { db, roles, .. }): State<AppState>,
+) -> Response<u64> {
+    if roles
+        .get_current(level)
+        .filter(|v| v.permissions.services_manage)
+        .is_none()
+    {
+        let res = sqlx::query!(
+            "
+            SELECT spaces.owner_id
+            FROM service_accounts
+                INNER JOIN spaces ON spaces.id = service_accounts.space_id
+            WHERE service_accounts.id = ?",
+            service_account_id
+        )
+        .fetch_optional(&db)
+        .await
+        .expect("database")
+        .filter(|v| v.owner_id == user_id);
+
+        if res.is_none() {
+            return Response::Failture(api::Error::ObjectNotFound.into());
+        }
+    }
+
+    let res = sqlx::query!(
+        "DELETE FROM service_tokens WHERE service_id = ?",
+        service_account_id
+    )
+    .execute(&db)
+    .await
+    .expect("database");
+
+    Response::Success(res.rows_affected())
 }

--- a/archk/Cargo.toml
+++ b/archk/Cargo.toml
@@ -5,9 +5,10 @@ edition = "2021"
 publish = false
 
 [features]
-default = []
+default = ["ssh"]
 axum = ["dep:axum"]
-derive = ["dep:documentation-macro"]
+derive = []
+ssh = ["dep:russh-keys"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
@@ -20,8 +21,9 @@ regex = "1"
 uuid = { version = "1.10", features = ["v4", "fast-rng"] }
 
 axum = { version = "0.7", optional = true }
+russh-keys = { version = "0.44", optional = true }
 
-documentation-macro = { path = "../documentation-macro", optional = true }
+documentation-macro = { path = "../documentation-macro" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/archk/src/v1/auth.rs
+++ b/archk/src/v1/auth.rs
@@ -63,6 +63,7 @@ impl TokenTy {
     pub fn from_prefix(prefix: &str) -> Option<Self> {
         match prefix {
             "acp" => Some(Self::Personal),
+            "acs" => Some(Self::Service),
             _ => None,
         }
     }

--- a/archk/src/v1/auth.rs
+++ b/archk/src/v1/auth.rs
@@ -29,6 +29,9 @@ use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 pub enum TokenTy {
     /// Personal tokens, issued for users
     Personal,
+
+    /// Tokens that belongs to service accounts.
+    Service,
 }
 
 impl TokenTy {
@@ -43,6 +46,7 @@ impl TokenTy {
     pub fn prefix(self) -> &'static str {
         match self {
             Self::Personal => "acp",
+            Self::Service => "acs",
         }
     }
     /// Convert prefix to [`TokenTy`].

--- a/archk/src/v1/docs.rs
+++ b/archk/src/v1/docs.rs
@@ -149,12 +149,18 @@ pub trait Documentation {
 /// assert_eq!(<MyType as Documentation>::DOCUMENTATION_OBJECT.name, "MyType");
 /// ```
 macro_rules! impl_documentation {
-    ($($v:ident)*) => {
-        $(
-            impl crate::v1::docs::Documentation for $v {
-                const DOCUMENTATION_OBJECT: crate::v1::docs::DocumentationObject = crate::v1::docs::DocumentationObject::new(stringify!($v), "", &[]);
-            }
-    )   *
+    ($ty:ident as $orig:ident) => {
+        impl crate::v1::docs::Documentation for $ty {
+            const DOCUMENTATION_OBJECT: crate::v1::docs::DocumentationObject = crate::v1::docs::DocumentationObject::new(stringify!($orig), "", &[]);
+        }
+    };
+
+    ($v:ident) => {
+        impl_documentation!($v as $v);
+    };
+
+    ($($v:ident)+) => {
+        $( impl_documentation!($v); )*
     };
 }
 pub(crate) use impl_documentation;

--- a/archk/src/v1/mod.rs
+++ b/archk/src/v1/mod.rs
@@ -19,6 +19,7 @@ pub mod errors {
     /// Invalid enum variant passed.
     ///
     /// Example: attempt to call [`TryFrom::try_from`] on value that not described in enum.
+    #[derive(Debug)]
     pub struct NoEnumVariantError(pub(crate) ());
 
     impl std::fmt::Display for NoEnumVariantError {
@@ -31,6 +32,7 @@ pub mod errors {
     ///
     /// Example: attempt to call [`TryFrom::try_from`] on string that not CUID string.
     /// Used in CUID objects like [`super::user::UserID`].
+    #[derive(Debug)]
     pub struct StringIsNotCUID(pub(crate) ());
 
     impl std::fmt::Display for StringIsNotCUID {

--- a/archk/src/v1/mod.rs
+++ b/archk/src/v1/mod.rs
@@ -1,5 +1,7 @@
 /// Authorization models
 pub mod auth;
+/// Service accounts models
+pub mod service;
 /// Space models
 pub mod space;
 /// User models

--- a/archk/src/v1/service.rs
+++ b/archk/src/v1/service.rs
@@ -1,0 +1,36 @@
+use serde::{Deserialize, Serialize};
+
+use super::{
+    macros::{impl_cuid, impl_try_from_enum},
+    space::SpaceID,
+};
+
+/// Represents ID of service account (CUID)
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+#[serde(into = "String", try_from = "String")]
+#[repr(transparent)]
+pub struct ServiceAccountID(String);
+impl_cuid!(ServiceAccountID);
+
+impl_try_from_enum!(
+    /// Type of service account independ of it's space
+    #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+    #[serde(into = "i64", try_from = "i64")]
+    pub enum ServiceAccountTy : repr(i64) {
+        /// Service that can get users by their ssh keys.
+        SSHAuthority = 1,
+
+        /// Can watch any event of space
+        SpaceEventWatcher = 1000,
+        /// Can report any supported type of action
+        SpaceActor = 1001,
+    }
+);
+
+/// Represents service account
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+pub struct ServiceAccount {
+    pub id: ServiceAccountID,
+    pub space_id: Option<SpaceID>,
+    pub ty: ServiceAccountTy,
+}

--- a/archk/src/v1/service.rs
+++ b/archk/src/v1/service.rs
@@ -27,6 +27,18 @@ impl_try_from_enum!(
     }
 );
 
+impl ServiceAccountTy {
+    /// Is space required to this type?
+    pub fn is_space_required(self) -> bool {
+        matches!(self, Self::SpaceEventWatcher | Self::SpaceActor)
+    }
+
+    /// Is can be created only by instance admins?
+    pub fn is_admin(self) -> bool {
+        matches!(self, Self::SSHAuthority)
+    }
+}
+
 /// Represents service account
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct ServiceAccount {

--- a/archk/src/v1/user.rs
+++ b/archk/src/v1/user.rs
@@ -83,3 +83,147 @@ pub fn is_valid_username(v: &str) -> bool {
 
     RE.is_match(v)
 }
+
+#[cfg(feature = "ssh")]
+pub mod ssh {
+    use serde::{Deserialize, Serialize};
+
+    use crate::v1::{
+        errors::NoEnumVariantError,
+        macros::{impl_cuid, impl_try_from_enum},
+    };
+
+    /// Represents ID of user ssh key (CUID)
+    #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+    #[repr(transparent)]
+    pub struct UserSSHKeyID(String);
+    impl_cuid!(UserSSHKeyID);
+
+    impl_try_from_enum!(
+        /// Supported ssh key types.
+        ///
+        /// # Example
+        /// ```
+        /// use archk::v1::user::ssh::SSHKeyTy;
+        ///
+        /// // Obrain from string:
+        /// let ty = SSHKeyTy::try_from("ssh-rsa").ok().expect("invalid string");
+        /// assert_eq!(ty, SSHKeyTy::RSA);
+        ///
+        /// // Convert to number:
+        /// let ty_id: i64 = ty.into();
+        /// assert_eq!(ty_id, 0);
+        ///
+        /// // Convert to string (default in (de)serializing):
+        /// let ty_str: &str = SSHKeyTy::ED25519.into();
+        /// assert_eq!(ty_str, "ssh-ed25519");
+        /// ```
+        #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug)]
+        #[repr(i64)]
+        pub enum SSHKeyTy : repr(i64) {
+            #[serde(rename = "ssh-rsa")]
+            RSA = 0,
+            #[serde(rename = "ssh-ed25519")]
+            ED25519 = 1,
+        }
+    );
+
+    impl<'a> TryFrom<&'a str> for SSHKeyTy {
+        type Error = NoEnumVariantError;
+
+        fn try_from(value: &'a str) -> Result<Self, NoEnumVariantError> {
+            match value {
+                "ssh-rsa" => Ok(Self::RSA),
+                "ssh-ed25519" => Ok(Self::ED25519),
+                _ => Err(NoEnumVariantError(())),
+            }
+        }
+    }
+    impl From<SSHKeyTy> for &'static str {
+        fn from(value: SSHKeyTy) -> Self {
+            match value {
+                SSHKeyTy::ED25519 => "ssh-ed25519",
+                SSHKeyTy::RSA => "ssh-rsa",
+            }
+        }
+    }
+
+    /// User ssh key.
+    #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+    pub struct UserSSHKey {
+        /// Key ID
+        pub id: UserSSHKeyID,
+        /// Key type
+        pub pubkey_ty: SSHKeyTy,
+        /// Key value (long public key string)
+        pub pubkey_val: String,
+        /// Key fingerprint hashed with sha2-256 in base64 without any prefixes
+        pub pubkey_fingerprint: String,
+    }
+
+    #[derive(Debug)]
+    pub enum FromPubkeyStrError {
+        /// Key type not known in [`SSHKeyTy`]
+        UnknownType,
+        /// Invalid public key format (not in `ssh-ty <BASE64>`)
+        InvalidString,
+        /// Returned from [`russh_keys::parse_public_key_base64`]
+        Parse(russh_keys::Error),
+    }
+
+    impl UserSSHKey {
+        /// Verify and construct new [`UserSSHKey`]
+        pub fn from_pubkey(pubkey_str: &str) -> Result<Self, FromPubkeyStrError> {
+            let (ty, key) = {
+                let mut split = pubkey_str.split(' ');
+
+                (split.next(), split.next())
+            };
+
+            let (ty, key) = match (ty.map(SSHKeyTy::try_from), key) {
+                (Some(Ok(ty)), Some(key)) => (ty, key),
+                (Some(Err(_)), _) => return Err(FromPubkeyStrError::UnknownType),
+                _ => todo!(),
+            };
+
+            let pubkey =
+                russh_keys::parse_public_key_base64(key).map_err(FromPubkeyStrError::Parse)?;
+
+            let fingerprint = pubkey.fingerprint();
+
+            Ok(Self {
+                id: UserSSHKeyID::new(),
+                pubkey_ty: ty,
+                pubkey_val: String::from(key),
+                pubkey_fingerprint: fingerprint,
+            })
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::{SSHKeyTy, UserSSHKey};
+
+        // This test ensures that fingerprint from `ssh-keygen` or somewhere matches
+        // to fingerprint from `russh_keys` (format).
+        // To get fingerprint run `echo "$KEYTYPE $KEYVAL" | ssh-keygen -l -f -`:
+        // ```
+        // $ echo "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ..." | ssh-keygen -l -f -
+        // 256 SHA256:ssIlIUznbRQkztvj/g8m7ybGlV1+1mQfbNnHo8TteJQ no comment (ED25519)
+        //            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ this part
+        // ```
+        #[test]
+        pub fn parse_ssh_public_keys() {
+            let keys = [
+                ("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC1/sXPq8Dln/vYYFCjkMsNRoObcX5M2BSyRyfJsR8bujf1jaPaEMVRGLp2CpNNkaCpsz1L1ObNPgYMm4Z9aPcly5EPf4tAL12P0cTZLpZd9ohxMpBkWqs53mi4OBuvEUE7UwPPyQTZDqnJrpkSntc59p9rESVt5KC2kPGJ1vusA1QviUbHBAYu03XRBOc8FYxAQIgUYajavltJ+0+E6/YxvRtEh/eK14uZIbpJMaatcnD9VbVL6cC9RShpcOk2fen9s7mvjgH5zAVDFRx2l9xP37jYmhIevG8ByJD9fyNfKKBngImJ6yyScShguS5l2J+Y6yJqPduwUu6mkQrP37mz+CxPVEP/KHxQlrpWrK3MB6Mri37MMhAVuI51c7cxHW9R+xFHmuyljxXg/QyRwKjhNourHR7mvXQmKoIwxQuJVgWc0TOPptG2dIanzmigdDCTJE4XcX0Bb4YP21eZ1yNmU4Lnr1uuTFR/AN4iQz8TstBCbOfrXV0EaRqmch9pXh0=", SSHKeyTy::RSA, "wATXSnzsU0YBTZTY5b7EAgAuL4VlLJ/IBU2ge2tZuZE"),
+                ("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJBbH545J25TMANrQRrqMO/SGSc+NMHpWgvWBptO+o7A comment", SSHKeyTy::ED25519, "ssIlIUznbRQkztvj/g8m7ybGlV1+1mQfbNnHo8TteJQ")
+            ];
+
+            for (key, expected_ty, expected_fingerprint) in keys {
+                let pubkey = UserSSHKey::from_pubkey(key).expect("UserSSHKey::from_pubkey");
+                assert_eq!(pubkey.pubkey_ty, expected_ty);
+                assert_eq!(pubkey.pubkey_fingerprint, expected_fingerprint);
+            }
+        }
+    }
+}

--- a/archk/src/v1/user.rs
+++ b/archk/src/v1/user.rs
@@ -86,9 +86,11 @@ pub fn is_valid_username(v: &str) -> bool {
 
 #[cfg(feature = "ssh")]
 pub mod ssh {
+    use documentation_macro::Documentation;
     use serde::{Deserialize, Serialize};
 
     use crate::v1::{
+        docs::impl_documentation,
         errors::NoEnumVariantError,
         macros::{impl_cuid, impl_try_from_enum},
     };
@@ -98,6 +100,7 @@ pub mod ssh {
     #[repr(transparent)]
     pub struct UserSSHKeyID(String);
     impl_cuid!(UserSSHKeyID);
+    impl_documentation!(UserSSHKeyID);
 
     impl_try_from_enum!(
         /// Supported ssh key types.
@@ -148,8 +151,11 @@ pub mod ssh {
         }
     }
 
+    // On serialization SSHKeyTy is actually string
+    impl_documentation!(SSHKeyTy as String);
+
     /// User ssh key.
-    #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+    #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug, Documentation)]
     pub struct UserSSHKey {
         /// Key ID
         pub id: UserSSHKeyID,

--- a/config.example.yml
+++ b/config.example.yml
@@ -19,6 +19,10 @@ server:
         spaces: true
         # Can manage spaces of others?
         spaces_manage: true
+        # Can create and manage space-related services?
+        services: true
+        # Can manage all services and create admin services?
+        services_manage: true
     - name: Moderator
       level: 90
       permissions:


### PR DESCRIPTION
First implementation of service accounts, including implementation of ssh keys service authorization.

> Using this branch on production very bad idea. Migration isn't final and may change.

### To-Do

- [x] Write database migration
- [x] Write types in `archk` crate for service accounts and user's ssh keys
   - ~~[ ] Implement `Documentation` on it~~ See #4 
- [x] Write service endpoints (create, ~~modify~~, delete, issue token, revoke all tokens):
   - [x] Write admin service endpoints (services without space)
   - [x] Write space service endpoints
- [x] Write SSH keys check endpoint for ssh service
   - [x] Endpoints: SSH key management for users
   - [x] Endpoint: Find keys by their fingerprint
- [x] Add `name` for `service_account`, write `PATCH` endpoint for it.

### Idea

Services is accounts with their tokens with limited access to spaces. Depends on service type it can fetch logs or push events but can't manage space.

### Legacy

Some services may work with "legacy" tokens (from [`v0`](https://github.com/Amchik/rfid-mugs-api)). Old tokens should be added to config with mapping to service ids.
