### PR TITLE
Implement space logs and space services

### DIFF
--- a/archk-api/src/v1/routes.rs
+++ b/archk-api/src/v1/routes.rs
@@ -125,12 +125,20 @@ routes! {
 
     GET "/space/:space_id/account/:acc_id/items" => space::get_items_of_account,
 
+    // Get logs for specific account. Supports paging.
+    GET "/space/:space_id/account/:acc_id/logs" => space::get_logs_by_account
+        :   res(Vec<space::SpaceItemLogEntry>),
+
     GET "/space/:space_id/item" => space::get_items,
     PUT "/space/:space_id/item" => space::create_item,
 
     GET    "/space/:space_id/item/:item_id" => space::get_item_by_id,
     PATCH  "/space/:space_id/item/:item_id" => space::patch_item,
     DELETE "/space/:space_id/item/:item_id" => space::delete_item,
+
+    // Get logs for specific item. Supports paging.
+    GET "/space/:space_id/item/:item_id/logs" => space::get_logs_by_item
+        :   res(Vec<space::SpaceItemLogEntry>),
 
     /// Get services bound to space. Supports pagging.
     GET "/space/:space_id/services" => service::get_space_services

--- a/archk-api/src/v1/space.rs
+++ b/archk-api/src/v1/space.rs
@@ -2,9 +2,7 @@ use archk::{
     v1::{
         api::{self, Response},
         models::MayIgnored,
-        space::{
-            Space, SpaceAccount, SpaceID, SpaceItem, SpaceItemID, SpaceItemTy, SpaceLogAction,
-        },
+        space::{Space, SpaceAccount, SpaceID, SpaceItem, SpaceItemID, SpaceItemTy},
         user::{User, UserID},
     },
     Documentation,

--- a/archk/src/v1/service.rs
+++ b/archk/src/v1/service.rs
@@ -20,17 +20,22 @@ impl_try_from_enum!(
         /// Service that can get users by their ssh keys.
         SSHAuthority = 1,
 
-        /// Can watch any event of space
+        /// Can watch for lock status
         SpaceEventWatcher = 1000,
-        /// Can report any supported type of action
+        /// Can report new serial, confirmation and report requests
         SpaceActor = 1001,
+        /// Can ask for registration, request unlocks and read reports
+        SpaceManager = 1002,
     }
 );
 
 impl ServiceAccountTy {
     /// Is space required to this type?
     pub fn is_space_required(self) -> bool {
-        matches!(self, Self::SpaceEventWatcher | Self::SpaceActor)
+        matches!(
+            self,
+            Self::SpaceEventWatcher | Self::SpaceActor | Self::SpaceManager
+        )
     }
 
     /// Is can be created only by instance admins?

--- a/archk/src/v1/space.rs
+++ b/archk/src/v1/space.rs
@@ -115,6 +115,10 @@ impl_try_from_enum!(
         ItemTaken = 200,
         ItemReturned = 300,
         StoredItemReturned = 301,
+        /// Someone requested to register his item of type [`SpaceItemTy::Normal`]
+        RequestedItemNormalRegistration = 400,
+        /// Someone requested to register his keycard (item of type [`SpaceItemTy::Keycard`])
+        RequestedItemKeycardRegistration = 401,
     }
 );
 

--- a/archk/src/v1/space.rs
+++ b/archk/src/v1/space.rs
@@ -111,8 +111,10 @@ impl_try_from_enum!(
     #[serde(into = "i64", try_from = "i64")]
     pub enum SpaceLogAction : repr(i64) {
         KeycardScanned = 100,
+        OpenRequested = 101,
         ItemTaken = 200,
         ItemReturned = 300,
+        StoredItemReturned = 301,
     }
 );
 


### PR DESCRIPTION
Resolves #5 

### To-Do list
- [x] **General:** Write `GET /space/:id/(item|account)/:_/logs`
- [ ] **SpaceEventWatcher**: Write API to obtain:
   - [ ] Open requests
- [ ] **SpaceActor**: Write API to do:
   - [ ] Send `read`/`confirm`/`report` events
- [ ] **SpaceManager**: Write API to:
   - [ ] Ask for items registration
   - [ ] Send `unblock` events
   - [ ] Obtain reports info
   
### Documentation

Some endpoints will not documented. After marking pull request as ready to merge add all undocumented endpoints to #4 

### Compatibility

This change does not affects API version 0.
  